### PR TITLE
Updated reference and citation limits

### DIFF
--- a/src/apis/s2agAPI.ts
+++ b/src/apis/s2agAPI.ts
@@ -26,7 +26,7 @@ export const getReferenceItems = async (
 	paperId: string,
 	debugMode = false
 ): Promise<Reference[]> => {
-	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/references?fields=${SEMANTIC_FIELDS.join(
+	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/references?limit=1000&fields=${SEMANTIC_FIELDS.join(
 		','
 	)}`
 	const references: Reference[] = await requestUrl(url).then(
@@ -45,7 +45,7 @@ export const getCitationItems = async (
 	paperId: string,
 	debugMode = false
 ): Promise<Reference[]> => {
-	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/citations?fields=${SEMANTIC_FIELDS.join(
+	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/citations?limit=1000&fields=${SEMANTIC_FIELDS.join(
 		','
 	)}`
 	const citations: Reference[] = await requestUrl(url).then(


### PR DESCRIPTION
Set a limit of 1000 references and citations, the max allowed by the semantic scholar API. The default is 100.