### PR TITLE
Support for tldr

### DIFF
--- a/src/apis/s2agAPI.ts
+++ b/src/apis/s2agAPI.ts
@@ -26,7 +26,7 @@ export const getReferenceItems = async (
 	paperId: string,
 	debugMode = false
 ): Promise<Reference[]> => {
-	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/references?fields=${SEMANTIC_FIELDS.join(
+	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/references?limit=1000&fields=${SEMANTIC_FIELDS.join(
 		','
 	)}`
 	const references: Reference[] = await requestUrl(url).then(
@@ -45,7 +45,7 @@ export const getCitationItems = async (
 	paperId: string,
 	debugMode = false
 ): Promise<Reference[]> => {
-	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/citations?fields=${SEMANTIC_FIELDS.join(
+	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}/citations?limit=1000&fields=${SEMANTIC_FIELDS.join(
 		','
 	)}`
 	const citations: Reference[] = await requestUrl(url).then(

--- a/src/apis/s2agAPI.ts
+++ b/src/apis/s2agAPI.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import { requestUrl } from 'obsidian'
-import { SEMANTIC_FIELDS, SEMANTICSCHOLAR_API_URL } from 'src/constants'
+import { SEMANTIC_FIELDS, SEMANTIC_FIELDS_PAPER_ONLY, SEMANTIC_FIELDS_SEARCH_ONLY, SEMANTICSCHOLAR_API_URL } from 'src/constants'
 import { Reference } from 'src/types'
 
 export const getIndexItem = async (
@@ -9,7 +9,7 @@ export const getIndexItem = async (
 ): Promise<Reference | null> => {
 	const url = `${SEMANTICSCHOLAR_API_URL}/paper/${paperId}?fields=${SEMANTIC_FIELDS.join(
 		','
-	)}`
+	)},${SEMANTIC_FIELDS_PAPER_ONLY.join(',')}`
 	const paperMetadata: Reference | null = await requestUrl(url).then(
 		(response) => {
 			if (response.status !== 200) {
@@ -67,7 +67,7 @@ export const getSearchItems = async (
 ): Promise<Reference[]> => {
 	let url = `${SEMANTICSCHOLAR_API_URL}/paper/search?query=${query}&fields=${SEMANTIC_FIELDS.join(
 		','
-	)}`
+	)},${SEMANTIC_FIELDS_SEARCH_ONLY.join(',')}`
 	if (limit !== 0) url += `&offset=0&limit=${limit}`
 	const search: Reference[] = await requestUrl(url).then((response) => {
 		if (response.status !== 200) {
@@ -99,9 +99,9 @@ export const getPaperMetadata = async (
 		cite = 'citingPaper'
 	} else if (refType === 'search') {
 		if (query === '') return []
-		fields = `search?query=${query}&fields=${SEMANTIC_FIELDS.join(',')}`
+		fields = `search?query=${query}&fields=${SEMANTIC_FIELDS.join(',')},${SEMANTIC_FIELDS_SEARCH_ONLY.join(',')}`
 	} else {
-		fields = `${paperId}?fields=${SEMANTIC_FIELDS.join(',')}`
+		fields = `${paperId}?fields=${SEMANTIC_FIELDS.join(',')},${SEMANTIC_FIELDS_PAPER_ONLY.join(',')}`
 	}
 
 	if (offset != 0) fields += `&offset=${offset}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,6 +105,12 @@ export const SEMANTIC_FIELDS = [
 	'year',
 	'citationStyles',
 ]
+export const SEMANTIC_FIELDS_PAPER_ONLY = [
+	'tldr',
+]
+export const SEMANTIC_FIELDS_SEARCH_ONLY = [
+	'tldr',
+]
 export const SEARCH_PARAMETERS = [
 	'paperId',
 	'externalIds',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -120,15 +120,15 @@ export default {
 	METADATA_COPY_TEMPLATE_ONE: `${clipBoard} Metadata One Template`,
 	METADATA_COPY_TEMPLATE_ONE_DESC:
 		'Template of the metadata to be copied to the clipboard.<br>' +
-		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
+		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{tldr}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
 	METADATA_COPY_TEMPLATE_TWO: `${papeClip} Metadata Two Template`,
 	METADATA_COPY_TEMPLATE_TWO_DESC:
 		'Template of the metadata to be copied to the clipboard.<br>' +
-		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
+		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{tldr}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
 	METADATA_COPY_TEMPLATE_THREE: `${clipboardData} Metadata Three Template`,
 	METADATA_COPY_TEMPLATE_THREE_DESC:
 		'Template of the metadata to be copied to the clipboard.<br>' +
-		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
+		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{tldr}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
 	METADATA_COPY_ONE_BATCH: `${clipBoard} Metadata One Batch`,
 	METADATA_COPY_ONE_BATCH_DESC:
 		'Copy metadata for all the references(cited papers) to the clipboard.<br>' +
@@ -154,13 +154,13 @@ export default {
 	MODAL_SEARCH_CREATE_FOLDER_DESC: 'Folder location to create the new reference. Relative to the vault root. If left blank, the new reference will be created in the vault root.',
 	MODAL_SEARCH_CREATE_FILE_FORMAT: 'File Name Format',
 	MODAL_SEARCH_CREATE_FILE_FORMAT_DESC: 'File name format to create the new reference. <br>' +
-		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
+		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{tldr}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
 	MODAL_SEARCH_CREATE_FILE_TEMPLATE: 'Template for New Note',
 	MODAL_SEARCH_CREATE_FILE_TEMPLATE_DESC: 'Template to create the new reference markdown file.<br>' +
-		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
+		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{tldr}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
 	MODAL_SEARCH_INSERT_TEMPLATE: 'Template for Inserting to Current Note',
 	MODAL_SEARCH_INSERT_TEMPLATE_DESC: 'Template to insert the reference metadata in the current note at the cursor position.<br>' +
-		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
+		'Valid variables are <code>{{id}}</code>, <code>{{title}}</code>, <code>{{author}}</code>, <code>{{authors}}</code>, <code>{{journal}}</code>, <code>{{volume}}</code>, <code>{{pages}}</code>, <code>{{year}}</code>, <code>{{abstract}}</code>, <code>{{tldr}}</code>, <code>{{url}}</code>, <code>{{pdfurl}}</code>, <code>{{doi}}</code>, <code>{{bibtex}}</code>',
 	// Debug settings
 	DEBUG_MODE: 'Debug Mode',
 	DEBUG_MODE_DESC:

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export interface Reference {
 	url: string
 	title: string
 	abstract: string
+	tldr: TLDR
 	venue: string
 	year: number
 	referenceCount: number
@@ -68,6 +69,11 @@ export interface ExternalIds {
 export interface OpenAccessPdf {
 	url: string
 	status: string
+}
+
+export interface TLDR {
+	model: string
+	text: string
 }
 
 export interface Journal {
@@ -110,6 +116,7 @@ export interface MetaData {
 	volume: string
 	pages: string
 	abstract: string
+	tldr: string
 	url: string
 	pdfurl: string
 	doi: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,6 +215,9 @@ export const makeMetaData = (paper: Reference): MetaData => {
 	const abstract = paper.abstract
 		? paper.abstract.trim()
 		: 'No abstract available'
+	const tldr = paper.tldr
+		? paper.tldr.text.trim()
+		: 'No TLDR available'
 	const bibTex = paper.citationStyles?.bibtex
 		? paper.citationStyles.bibtex
 		: 'No BibTex available'
@@ -245,6 +248,7 @@ export const makeMetaData = (paper: Reference): MetaData => {
 		volume: volume,
 		pages: pages,
 		abstract: abstract,
+		tldr: tldr,
 		url: paperURL,
 		pdfurl: openAccessPdfUrl,
 		doi: doi,
@@ -267,6 +271,7 @@ export const templateReplace = (template: string, data: MetaData, id = '') => {
 		.replaceAll('{{volume}}', data.volume.replace(/[:\\\\/]/g, ''))
 		.replaceAll('{{pages}}', data.pages.replace(/[:\\\\/]/g, ''))
 		.replaceAll('{{abstract}}', data.abstract)
+		.replaceAll('{{tldr}}', data.tldr)
 		.replaceAll('{{url}}', data.url)
 		.replaceAll('{{pdfurl}}', data.pdfurl)
 		.replaceAll('{{doi}}', data.doi)


### PR DESCRIPTION
There are some unfortunate limitations to this since the Semantic Scholar API doesn't support "tldr" from their references and citations APIs, but it works in most cases.

I updated the getPaperMetadata method, but it doesn't appear to be in use.
I didn't update the postPaperMetadata, which also doesn't appear to be in use.